### PR TITLE
Update instructions in the Applications view for setting the Kubernetes context

### DIFF
--- a/k8s/spinnaker/templates/spinnaker_application_manifest_middle_secured.yaml
+++ b/k8s/spinnaker/templates/spinnaker_application_manifest_middle_secured.yaml
@@ -2,7 +2,7 @@
       # Manage your Spinnaker
       [Open Management Environment in Cloud Shell](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/click-to-deploy.git&cloudshell_working_dir=k8s/spinnaker/scripts/manage&cloudshell_tutorial=landing_page_expanded.md)
 
-      Ensure you are connected to the correct GKE Cluster from within Cloud Shell. Follow the instructions in the Management environment to check the Kubernetes context you are using and update it if necessary.
+      Ensure you are connected to the correct GKE Cluster from within Cloud Shell. Follow the instructions in the Management Environment to check the Kubernetes context you are using and update it if necessary.
 
       # Connect to your Spinnaker
       [https://$DOMAIN_NAME](https://$DOMAIN_NAME)

--- a/k8s/spinnaker/templates/spinnaker_application_manifest_middle_secured.yaml
+++ b/k8s/spinnaker/templates/spinnaker_application_manifest_middle_secured.yaml
@@ -2,10 +2,7 @@
       # Manage your Spinnaker
       [Open Management Environment in Cloud Shell](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/click-to-deploy.git&cloudshell_working_dir=k8s/spinnaker/scripts/manage&cloudshell_tutorial=landing_page_expanded.md)
 
-      Ensure you are connected to the correct GKE Cluster from within Cloud Shell:
-      ```
-      gcloud container clusters get-credentials $GKE_CLUSTER --zone $ZONE --project $PROJECT_ID
-      ```
+      Ensure you are connected to the correct GKE Cluster from within Cloud Shell. Follow the instructions in the Management environment to check the Kubernetes context you are using and update it if necessary.
 
       # Connect to your Spinnaker
       [https://$DOMAIN_NAME](https://$DOMAIN_NAME)


### PR DESCRIPTION
For context: before this change, we are providing two different ways of achieving the desired goal (which is to make sure you are speaking to the correct Spinnaker installation from your Management Environment):

1. You can copy-paste the command from the Application view, then run it in Cloud Shell
1. You can run the command we provide in the Cloud Shell tutorial to check and set your context

The intent here is to simplify the approach to always say: "as an admin, when you get into the Management Environment, the first thing to do is check and set your context using the provided command."

Even though the script is slightly less foolproof in that it has to make an educated guess about the context, I think it's preferable to have only one way to this.