### PR TITLE
Add jsonKey for the path rewrites

### DIFF
--- a/k8s/spinnaker/scripts/manage/add_gae_account.sh
+++ b/k8s/spinnaker/scripts/manage/add_gae_account.sh
@@ -6,7 +6,7 @@ bold() {
 
 source ~/click-to-deploy/k8s/spinnaker/scripts/install/properties
 
-read -e -p "Please enter the id of the project within which you wish to manage GCE resources: " -i $PROJECT_ID MANAGED_PROJECT_ID
+read -e -p "Please enter the id of the project within which you wish to manage GAE resources: " -i $PROJECT_ID MANAGED_PROJECT_ID
 read -e -p "Please enter a name for the new Spinnaker account: " -i "$MANAGED_PROJECT_ID-acct" GAE_ACCOUNT_NAME
 
 bold "Assigning required roles to $SERVICE_ACCOUNT_NAME..."
@@ -16,7 +16,7 @@ SA_EMAIL=$(gcloud iam service-accounts --project $PROJECT_ID list \
   --format='value(email)')
 
 #GAE_REQUIRED_ROLES=(compute.instanceAdmin compute.networkAdmin compute.securityAdmin compute.storageAdmin iam.serviceAccountUser)
-GAE_REQUIRED_ROLES=(roles/storage.admin roles/appengine.appAdmin)
+GAE_REQUIRED_ROLES=(storage.admin appengine.appAdmin)
 EXISTING_ROLES=$(gcloud projects get-iam-policy --filter bindings.members:$SA_EMAIL $MANAGED_PROJECT_ID \
   --flatten bindings[].members --format="value(bindings.role)")
 

--- a/k8s/spinnaker/scripts/manage/add_gae_account.sh
+++ b/k8s/spinnaker/scripts/manage/add_gae_account.sh
@@ -15,7 +15,6 @@ SA_EMAIL=$(gcloud iam service-accounts --project $PROJECT_ID list \
   --filter="displayName:$SERVICE_ACCOUNT_NAME" \
   --format='value(email)')
 
-#GAE_REQUIRED_ROLES=(compute.instanceAdmin compute.networkAdmin compute.securityAdmin compute.storageAdmin iam.serviceAccountUser)
 GAE_REQUIRED_ROLES=(storage.admin appengine.appAdmin)
 EXISTING_ROLES=$(gcloud projects get-iam-policy --filter bindings.members:$SA_EMAIL $MANAGED_PROJECT_ID \
   --flatten bindings[].members --format="value(bindings.role)")

--- a/k8s/spinnaker/scripts/manage/add_gae_account.sh
+++ b/k8s/spinnaker/scripts/manage/add_gae_account.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+bold() {
+  echo ". $(tput bold)" "$*" "$(tput sgr0)";
+}
+
+source ~/click-to-deploy/k8s/spinnaker/scripts/install/properties
+
+read -e -p "Please enter the id of the project within which you wish to manage GCE resources: " -i $PROJECT_ID MANAGED_PROJECT_ID
+read -e -p "Please enter a name for the new Spinnaker account: " -i "$MANAGED_PROJECT_ID-acct" GAE_ACCOUNT_NAME
+
+bold "Assigning required roles to $SERVICE_ACCOUNT_NAME..."
+
+SA_EMAIL=$(gcloud iam service-accounts --project $PROJECT_ID list \
+  --filter="displayName:$SERVICE_ACCOUNT_NAME" \
+  --format='value(email)')
+
+#GAE_REQUIRED_ROLES=(compute.instanceAdmin compute.networkAdmin compute.securityAdmin compute.storageAdmin iam.serviceAccountUser)
+GAE_REQUIRED_ROLES=(roles/storage.admin roles/appengine.appAdmin)
+EXISTING_ROLES=$(gcloud projects get-iam-policy --filter bindings.members:$SA_EMAIL $MANAGED_PROJECT_ID \
+  --flatten bindings[].members --format="value(bindings.role)")
+
+for r in "${GAE_REQUIRED_ROLES[@]}"; do
+  if [ -z "$(echo $EXISTING_ROLES | grep $r)" ]; then
+    bold "Assigning role $r in project $MANAGED_PROJECT_ID to service account $SA_EMAIL..."
+    gcloud projects add-iam-policy-binding $MANAGED_PROJECT_ID \
+      --member serviceAccount:$SA_EMAIL \
+      --role roles/$r \
+      --format=none
+  fi
+done
+
+~/hal/hal config provider appengine enable
+~/hal/hal config provider appengine account add $GAE_ACCOUNT_NAME --project $MANAGED_PROJECT_ID

--- a/k8s/spinnaker/scripts/manage/landing_page_base.md
+++ b/k8s/spinnaker/scripts/manage/landing_page_base.md
@@ -132,6 +132,12 @@ clusters](https://www.spinnaker.io/setup/install/providers/kubernetes-v2/gke/).
 ~/click-to-deploy/k8s/spinnaker/scripts/manage/add_gce_account.sh
 ```
 
+### Add Spinnaker account for GAE
+
+```bash
+~/click-to-deploy/k8s/spinnaker/scripts/manage/add_gae_account.sh
+```
+
 ### Upgrade Spinnaker
 
 First, modify `SPINNAKER_VERSION` in your `properties` file to reflect the desired version of Spinnaker:

--- a/k8s/spinnaker/scripts/manage/push_config.sh
+++ b/k8s/spinnaker/scripts/manage/push_config.sh
@@ -57,7 +57,7 @@ done
 
 cp ~/.hal/config .hal
 
-REWRITABLE_KEYS=(kubeconfigFile jsonPath)
+REWRITABLE_KEYS=(kubeconfigFile jsonPath jsonKey)
 for k in "${REWRITABLE_KEYS[@]}"; do
   grep $k .hal/config &> /dev/null
   FOUND_TOKEN=$?


### PR DESCRIPTION
**Category:**

- [ ] Virtual machines
- [x ] Kubernetes apps
- [ ] Container images

---

<!-- 1. Please select the category from the list above. -->
<!-- 2. Please describe the PR below. -->

When adding an account for Google Cloud Build the label jsonKey is used instead of jsonPath. 
This PR adds 'jsonPath' to the list of paths to be rewritten.

https://www.spinnaker.io/setup/ci/gcb/
